### PR TITLE
[CHA-35] 사용자 정의 습관 등록 API 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+**/src/main/resources/application-dev.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15-alpine
+    container_name: chagok-postgres
+    environment:
+      POSTGRES_USER: chagok
+      POSTGRES_PASSWORD: chagok
+      POSTGRES_DB: chagok_db
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U chagok -d chagok_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  postgres_data:

--- a/src/main/java/com/jangjak/chagok/common/exception/ErrorCode.java
+++ b/src/main/java/com/jangjak/chagok/common/exception/ErrorCode.java
@@ -8,6 +8,8 @@ public enum ErrorCode {
     UNAUTHORIZED("인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
     FORBIDDEN("잘못된 접근입니다.", HttpStatus.FORBIDDEN),
     INTERNAL_SERVER_ERROR("서버 내부 오류입니다. 관리자에게 문의하세요.", HttpStatus.INTERNAL_SERVER_ERROR),
+    DATE_FORMAT_ERROR("잘못된 날짜 형식입니다. 날짜는 yyyyMMdd 형식으로 전달해주세요.", HttpStatus.BAD_REQUEST),
+    DATASET_ERROR("유효한 요청이지만 데이터를 찾을 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     ;
 
     final String message;

--- a/src/main/java/com/jangjak/chagok/habit/controller/HabitController.java
+++ b/src/main/java/com/jangjak/chagok/habit/controller/HabitController.java
@@ -1,7 +1,15 @@
 package com.jangjak.chagok.habit.controller;
 
+import com.jangjak.chagok.common.dto.CommonResponse;
+import com.jangjak.chagok.common.dto.TokenUserInfo;
+import com.jangjak.chagok.habit.dto.request.CustomHabitRequestDto;
+import com.jangjak.chagok.habit.service.creation.HabitCreateService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -10,5 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Slf4j
 public class HabitController {
+    private final HabitCreateService habitCreateService;
 
+    @PostMapping("/custom")
+    public ResponseEntity<?> createCustomHabit(@AuthenticationPrincipal TokenUserInfo userInfo, @RequestBody CustomHabitRequestDto reqDto) {
+        Long userHabitId = habitCreateService.createCustomHabit(reqDto, userInfo.getId());
+        return CommonResponse.toRes(userHabitId,"습관 생성이 완료되었습니다.");
+    }
 }

--- a/src/main/java/com/jangjak/chagok/habit/dto/request/ActionRequestDto.java
+++ b/src/main/java/com/jangjak/chagok/habit/dto/request/ActionRequestDto.java
@@ -1,0 +1,20 @@
+package com.jangjak.chagok.habit.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ActionRequestDto {
+    Integer sequence;
+    String content;
+    Integer freqSeq;
+    String checkMethod;
+    String actionDate;
+    String isCompleted;
+
+}

--- a/src/main/java/com/jangjak/chagok/habit/dto/request/CustomHabitRequestDto.java
+++ b/src/main/java/com/jangjak/chagok/habit/dto/request/CustomHabitRequestDto.java
@@ -1,0 +1,30 @@
+package com.jangjak.chagok.habit.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CustomHabitRequestDto {
+
+    // habitId가 있다면 있는 거 재활용
+    Long habitId;
+
+    // habitId가 없다면 다시 생성
+    Long categoryId;
+    String title;
+    Integer frequency;
+    Integer frequencyUnit;
+    Boolean isPublic;
+    List<ActionRequestDto> actions;
+
+    // Non-null 필드
+    String startDate;
+    String endDate;
+}

--- a/src/main/java/com/jangjak/chagok/habit/dto/value/HabitCreationInfo.java
+++ b/src/main/java/com/jangjak/chagok/habit/dto/value/HabitCreationInfo.java
@@ -1,0 +1,14 @@
+package com.jangjak.chagok.habit.dto.value;
+
+import com.jangjak.chagok.habit.entity.Action;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class HabitCreationInfo {
+    Long habitId;
+    List<Action> actions;
+}

--- a/src/main/java/com/jangjak/chagok/habit/dto/value/HabitDateInfo.java
+++ b/src/main/java/com/jangjak/chagok/habit/dto/value/HabitDateInfo.java
@@ -1,0 +1,13 @@
+package com.jangjak.chagok.habit.dto.value;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class HabitDateInfo {
+    LocalDate startDate;
+    LocalDate endDate;
+}

--- a/src/main/java/com/jangjak/chagok/habit/entity/Action.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/Action.java
@@ -1,0 +1,29 @@
+package com.jangjak.chagok.habit.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table
+public class Action {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long habitId;
+
+    private Integer sequence;
+
+    private String content;
+
+    private Integer freqSeq;
+
+    // Enum으로 관리
+    private String checkMethod;
+}

--- a/src/main/java/com/jangjak/chagok/habit/entity/Habit.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/Habit.java
@@ -1,0 +1,31 @@
+package com.jangjak.chagok.habit.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Habit {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long categoryId;
+
+    private String title;
+
+    private int frequency;
+
+    private String freqUnit;
+
+    // Y: 공개, N: 비공개
+    private String isPublic;
+}

--- a/src/main/java/com/jangjak/chagok/habit/entity/HabitCategory.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/HabitCategory.java
@@ -6,26 +6,15 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDate;
-
 @Entity
-@Table
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class Habit {
+@Table(name = "category")
+public class HabitCategory {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long categoryId;
-
-    private String title;
-
-    private Integer frequency;
-
-    private Integer freqUnit;
-
-    // Y: 공개, N: 비공개
-    private String isPublic;
+    private String name;
 }

--- a/src/main/java/com/jangjak/chagok/habit/entity/UserAction.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/UserAction.java
@@ -1,0 +1,28 @@
+package com.jangjak.chagok.habit.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table
+public class UserAction {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userHabitId;
+
+    private Long actionId;
+
+    private LocalDate actionDate;
+
+    private String isCompleted;
+}

--- a/src/main/java/com/jangjak/chagok/habit/entity/UserHabit.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/UserHabit.java
@@ -1,0 +1,25 @@
+package com.jangjak.chagok.habit.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Table
+public class UserHabit {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+    private Long habitId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/main/java/com/jangjak/chagok/habit/repository/ActionRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/ActionRepository.java
@@ -1,0 +1,10 @@
+package com.jangjak.chagok.habit.repository;
+
+import com.jangjak.chagok.habit.entity.Action;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ActionRepository extends JpaRepository<Action, Long> {
+    List<Action> getActionsByHabitId(Long habitId);
+}

--- a/src/main/java/com/jangjak/chagok/habit/repository/HabitCategoryRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/HabitCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.jangjak.chagok.habit.repository;
+
+import com.jangjak.chagok.habit.entity.HabitCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HabitCategoryRepository extends JpaRepository<HabitCategory, Long> {
+}

--- a/src/main/java/com/jangjak/chagok/habit/repository/HabitQuery.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/HabitQuery.java
@@ -29,7 +29,7 @@ public class HabitQuery {
     }
 
     public Long saveUserHabit(UserHabit userHabit) {
-        return userHabitRepository.save(userHabit).getHabitId();
+        return userHabitRepository.save(userHabit).getId();
     }
 
     public Habit saveHabit(Habit habit) {

--- a/src/main/java/com/jangjak/chagok/habit/repository/HabitQuery.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/HabitQuery.java
@@ -2,15 +2,9 @@ package com.jangjak.chagok.habit.repository;
 
 import com.jangjak.chagok.common.exception.CustomException;
 import com.jangjak.chagok.common.exception.ErrorCode;
-import com.jangjak.chagok.habit.entity.Action;
-import com.jangjak.chagok.habit.entity.Habit;
-import com.jangjak.chagok.habit.entity.UserAction;
-import com.jangjak.chagok.habit.entity.UserHabit;
+import com.jangjak.chagok.habit.entity.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.autoconfigure.data.jdbc.JdbcDataProperties;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -23,6 +17,7 @@ public class HabitQuery {
     private final ActionRepository actionRepository;
     private final UserHabitRepository userHabitRepository;
     private final UserActionRepository userActionRepository;
+    private final HabitCategoryRepository habitCategoryRepository;
 
     public Habit getHabitById(Long habitId) {
         return habitRepository.findById(habitId)
@@ -34,7 +29,7 @@ public class HabitQuery {
     }
 
     public Long saveUserHabit(UserHabit userHabit) {
-       return userHabitRepository.save(userHabit).getHabitId();
+        return userHabitRepository.save(userHabit).getHabitId();
     }
 
     public Habit saveHabit(Habit habit) {
@@ -48,5 +43,11 @@ public class HabitQuery {
 
     public void saveActionList(List<Action> actions) {
         actionRepository.saveAll(actions);
+    }
+
+    public HabitCategory getHabitCategoryById(Long categoryId) {
+        return habitCategoryRepository.findById(categoryId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND)
+        );
     }
 }

--- a/src/main/java/com/jangjak/chagok/habit/repository/HabitQuery.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/HabitQuery.java
@@ -1,0 +1,52 @@
+package com.jangjak.chagok.habit.repository;
+
+import com.jangjak.chagok.common.exception.CustomException;
+import com.jangjak.chagok.common.exception.ErrorCode;
+import com.jangjak.chagok.habit.entity.Action;
+import com.jangjak.chagok.habit.entity.Habit;
+import com.jangjak.chagok.habit.entity.UserAction;
+import com.jangjak.chagok.habit.entity.UserHabit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.data.jdbc.JdbcDataProperties;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.simple.JdbcClient;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class HabitQuery {
+    private final HabitRepository habitRepository;
+    private final ActionRepository actionRepository;
+    private final UserHabitRepository userHabitRepository;
+    private final UserActionRepository userActionRepository;
+
+    public Habit getHabitById(Long habitId) {
+        return habitRepository.findById(habitId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+    }
+
+    public List<Action> getActionsByHabitId(Long habitId) {
+        return actionRepository.getActionsByHabitId(habitId);
+    }
+
+    public Long saveUserHabit(UserHabit userHabit) {
+       return userHabitRepository.save(userHabit).getHabitId();
+    }
+
+    public Habit saveHabit(Habit habit) {
+        return habitRepository.save(habit);
+    }
+
+    // --- 추후 비동기 처리를 통해 대량 데이터 주입 시 성능 최적화 여부 고려 --- (굳이긴 합니다...)
+    public void saveUserActionList(List<UserAction> userActions) {
+        userActionRepository.saveAll(userActions);
+    }
+
+    public void saveActionList(List<Action> actions) {
+        actionRepository.saveAll(actions);
+    }
+}

--- a/src/main/java/com/jangjak/chagok/habit/repository/HabitRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/HabitRepository.java
@@ -1,0 +1,7 @@
+package com.jangjak.chagok.habit.repository;
+
+import com.jangjak.chagok.habit.entity.Habit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HabitRepository extends JpaRepository<Habit, Long> {
+}

--- a/src/main/java/com/jangjak/chagok/habit/repository/UserActionRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/UserActionRepository.java
@@ -1,0 +1,8 @@
+package com.jangjak.chagok.habit.repository;
+
+import com.jangjak.chagok.habit.entity.Action;
+import com.jangjak.chagok.habit.entity.UserAction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserActionRepository extends JpaRepository<UserAction, Long> {
+}

--- a/src/main/java/com/jangjak/chagok/habit/repository/UserHabitRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/UserHabitRepository.java
@@ -1,0 +1,8 @@
+package com.jangjak.chagok.habit.repository;
+
+import com.jangjak.chagok.habit.entity.UserAction;
+import com.jangjak.chagok.habit.entity.UserHabit;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserHabitRepository extends JpaRepository<UserHabit, Long> {
+}

--- a/src/main/java/com/jangjak/chagok/habit/service/creation/HabitCreateService.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/creation/HabitCreateService.java
@@ -1,0 +1,155 @@
+package com.jangjak.chagok.habit.service.creation;
+
+import com.jangjak.chagok.common.exception.CustomException;
+import com.jangjak.chagok.common.exception.ErrorCode;
+import com.jangjak.chagok.habit.dto.value.HabitDateInfo;
+import com.jangjak.chagok.habit.dto.request.CustomHabitRequestDto;
+import com.jangjak.chagok.habit.dto.value.HabitCreationInfo;
+import com.jangjak.chagok.habit.entity.Action;
+import com.jangjak.chagok.habit.entity.UserAction;
+import com.jangjak.chagok.habit.entity.UserHabit;
+import com.jangjak.chagok.habit.repository.HabitQuery;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * 습관 관련 비즈니스 로직을 처리하는 서비스 클래스
+ * 
+ * 주요 기능:
+ * - 사용자 정의 습관 생성 및 기존 습관 재활용
+ * - 습관과 연관된 액션들의 사용자별 상태 관리
+ * - Factory 패턴을 통한 습관 생성 전략 분리
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class HabitCreateService {
+    /** 습관 관련 데이터베이스 조회/저장을 담당하는 쿼리 클래스 */
+    private final HabitQuery habitQuery;
+    
+    /** 습관 생성 전략을 결정하는 팩토리 클래스 */
+    private final HabitCreationFactory creationFactory;
+
+    /**
+     * 사용자 정의 습관을 생성하거나 기존 습관을 재활용합니다.
+     * <p>
+     * 이 메서드는 두 가지 시나리오를 처리합니다:
+     * <ul>
+     *     <li>habitId가 제공된 경우: 기존 습관을 재활용합니다</li>
+     *     <li>habitId가 제공되지 않은 경우: 제공된 정보를 바탕으로 새로운 습관을 생성합니다</li>
+     * </ul>
+     * 참고: 입력 유효성 검증은 @Valid 어노테이션 대신 직접 구현되었습니다.
+     *
+     * @param reqDto 사용자 정의 습관 생성 요청 데이터
+     * @param userId 사용자 Id
+     */
+    public Long createCustomHabit(CustomHabitRequestDto reqDto, Long userId) {
+        // === 1단계: 입력 데이터 유효성 검증 ===
+        // 날짜 형식 검증 및 논리적 유효성 확인 (시작일 <= 종료일)
+        HabitDateInfo dateInfo = validateAndParseHabitDates(reqDto);
+
+        // === 2단계: 습관 및 액션 정보 준비 ===
+        // habitId 존재 여부에 따른 분기 처리 -> 추후 존재하는 습관을 고쳐 사용하는 로직이 따로 필요할 수도 있기 때문에 Factory 패턴 적용
+        HabitCreationInfo habitInfo = creationFactory.createHabit(reqDto);
+
+
+        // === 3단계: 사용자 습관 생성 ===
+        // 사용자와 습관을 연결하는 UserHabit 엔티티 생성
+        UserHabit userHabit = UserHabit.builder()
+                .userId(userId)         // 요청한 사용자 ID
+                .habitId(habitInfo.getHabitId())       // 습관 ID (기존 또는 새로 생성된)
+                .startDate(dateInfo.getStartDate())   // 습관 시작일
+                .endDate(dateInfo.getEndDate())       // 습관 종료일
+                .build();
+        
+        // UserHabit을 DB에 저장하고 생성된 ID 반환
+        Long userHabitId = habitQuery.saveUserHabit(userHabit);
+
+        // === 4단계: 사용자별 액션 상태 초기화 ===
+        // 각 액션에 대해 사용자별 실행 상태를 관리하는 UserAction 엔티티들을 생성
+        createUserActionsForHabit(habitInfo, userHabitId);
+
+        // 생성된 사용자 습관 ID 반환
+        return userHabitId;
+    }
+
+    /**
+     * 습관의 모든 액션에 대해 사용자별 실행 상태를 초기화합니다.
+     * 
+     * @param habitInfo 습관 정보 (습관 ID와 액션 목록 포함)
+     * @param userHabitId 방금 생성된 사용자 습관 ID
+     */
+    private void createUserActionsForHabit(HabitCreationInfo habitInfo, Long userHabitId) {
+        // 각 액션에 대해 사용자별 실행 상태를 관리하는 UserAction 엔티티 목록 생성
+        // LinkedList 사용: 순차적 추가가 많고 인덱스 접근이 없어 적합
+        List<UserAction> userActions = new LinkedList<>();
+
+        // 습관에 포함된 모든 액션에 대해 UserAction 생성
+        // 초기 상태는 모두 미완료("N")로 설정
+        for (Action action : habitInfo.getActions()) {
+            userActions.add(
+                    UserAction.builder()
+                            .userHabitId(userHabitId)    // 사용자 습관과 연결
+                            .actionId(action.getId())    // 원본 액션과 연결
+                            .isCompleted("N")            // 초기 완료 상태: 미완료
+                            .build()
+            );
+        }
+
+        // 배치 저장으로 성능 최적화
+        // application.yml의 hibernate.jdbc.batch_size=50 설정과
+        // rewriteBatchedInserts=true 옵션을 활용한 Bulk Insert
+        habitQuery.saveUserActionList(userActions);
+    }
+
+    /**
+     * 습관 시작일과 종료일의 유효성을 검증하고 LocalDate 객체로 변환합니다.
+     * 
+     * 검증 항목:
+     * 1. null 체크
+     * 2. 날짜 형식 검증 (yyyyMMdd)
+     * 3. 시작일 <= 종료일 논리적 유효성 검증
+     * 
+     * @param reqDto 사용자 요청 데이터
+     * @return 검증된 날짜 정보 객체
+     * @throws CustomException 날짜가 null이거나 형식이 잘못된 경우
+     * @throws CustomException 시작일이 종료일보다 늦은 경우
+     */
+    private HabitDateInfo validateAndParseHabitDates(CustomHabitRequestDto reqDto) {
+        // 필수 입력값 null 체크
+        if (reqDto.getStartDate() == null || reqDto.getEndDate() == null) {
+            throw new CustomException(ErrorCode.DATE_FORMAT_ERROR);
+        }
+
+        // 문자열 날짜를 LocalDate로 파싱
+        // 형식: "yyyyMMdd" (예: "20241005")
+        // DateTimeParseException 발생 시 상위로 전파됨
+        LocalDate startDate;
+        LocalDate endDate;
+        try {
+            startDate = LocalDate.parse(reqDto.getStartDate(), DateTimeFormatter.ofPattern("yyyyMMdd"));
+            endDate = LocalDate.parse(reqDto.getEndDate(), DateTimeFormatter.ofPattern("yyyyMMdd"));
+        } catch (DateTimeParseException e) {
+            throw new CustomException(ErrorCode.DATE_FORMAT_ERROR);
+        }
+
+        // 논리적 유효성 검증: 시작일이 종료일보다 늦으면 안됨
+        if (startDate.isAfter(endDate)) {
+            throw new CustomException(ErrorCode.BAD_REQUEST);
+        }
+        
+        // TODO: 추가 검증 필요
+        // - 시작일이 과거 날짜인지 확인
+        // - 최대 습관 기간 제한 (예: 1년)
+        // - 공휴일/주말 제외 옵션 등
+        
+        return new HabitDateInfo(startDate, endDate);
+    }
+}

--- a/src/main/java/com/jangjak/chagok/habit/service/creation/HabitCreationBase.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/creation/HabitCreationBase.java
@@ -1,0 +1,8 @@
+package com.jangjak.chagok.habit.service.creation;
+
+import com.jangjak.chagok.habit.dto.request.CustomHabitRequestDto;
+import com.jangjak.chagok.habit.dto.value.HabitCreationInfo;
+
+public abstract class HabitCreationBase {
+    public abstract HabitCreationInfo createHabit(CustomHabitRequestDto reqDto);
+}

--- a/src/main/java/com/jangjak/chagok/habit/service/creation/HabitCreationCustom.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/creation/HabitCreationCustom.java
@@ -1,0 +1,55 @@
+package com.jangjak.chagok.habit.service.creation;
+
+import com.jangjak.chagok.habit.dto.request.ActionRequestDto;
+import com.jangjak.chagok.habit.dto.request.CustomHabitRequestDto;
+import com.jangjak.chagok.habit.dto.value.HabitCreationInfo;
+import com.jangjak.chagok.habit.entity.Action;
+import com.jangjak.chagok.habit.entity.Habit;
+import com.jangjak.chagok.habit.repository.HabitQuery;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class HabitCreationCustom extends HabitCreationBase{
+    private final HabitQuery habitQuery;
+
+    @Override
+    public HabitCreationInfo createHabit(CustomHabitRequestDto reqDto) {
+        // === 2-2: 새로운 습관 생성 케이스 ===
+
+        // 요청 데이터를 기반으로 새로운 Habit 엔티티 생성
+        Habit rawHabit = Habit.builder()
+                .title(reqDto.getTitle())                    // 습관 제목
+                .categoryId(reqDto.getCategoryId())          // 카테고리 ID
+                .frequency(reqDto.getFrequency())            // 빈도 (횟수)
+                .freqUnit(reqDto.getFrequencyUnit())         // 빈도 단위 (일/주/월)
+                .isPublic(reqDto.getIsPublic() ? "Y" : "N")  // 공개 여부 (Boolean → String 변환)
+                .build();
+
+        // 생성된 습관을 DB에 저장하고 생성된 ID 반환
+        Long habitId = habitQuery.saveHabit(rawHabit).getId();
+
+        // 요청에 포함된 액션 목록을 Action 엔티티로 변환
+        List<ActionRequestDto> actionReqList = reqDto.getActions();
+        List<Action> actions = actionReqList.stream()
+                .map(value -> Action.builder()
+                        .habitId(habitId)                    // 방금 생성된 습관 ID 연결
+                        .sequence(value.getSequence())       // 액션 순서
+                        .content(value.getContent())         // 액션 내용
+                        .freqSeq(value.getFreqSeq())         // 빈도 순서
+                        .checkMethod(value.getCheckMethod()) // 체크 방법
+                        .build()
+                )
+                .toList();
+
+        // Action DB 저장
+        habitQuery.saveActionList(actions);
+
+        return new HabitCreationInfo(habitId, actions);
+    }
+}

--- a/src/main/java/com/jangjak/chagok/habit/service/creation/HabitCreationCustom.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/creation/HabitCreationCustom.java
@@ -5,6 +5,7 @@ import com.jangjak.chagok.habit.dto.request.CustomHabitRequestDto;
 import com.jangjak.chagok.habit.dto.value.HabitCreationInfo;
 import com.jangjak.chagok.habit.entity.Action;
 import com.jangjak.chagok.habit.entity.Habit;
+import com.jangjak.chagok.habit.entity.HabitCategory;
 import com.jangjak.chagok.habit.repository.HabitQuery;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +22,8 @@ public class HabitCreationCustom extends HabitCreationBase{
     @Override
     public HabitCreationInfo createHabit(CustomHabitRequestDto reqDto) {
         // === 2-2: 새로운 습관 생성 케이스 ===
+        // Category 존재 여부 검증
+        habitQuery.getHabitCategoryById(reqDto.getCategoryId());
 
         // 요청 데이터를 기반으로 새로운 Habit 엔티티 생성
         Habit rawHabit = Habit.builder()

--- a/src/main/java/com/jangjak/chagok/habit/service/creation/HabitCreationExisting.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/creation/HabitCreationExisting.java
@@ -1,0 +1,41 @@
+package com.jangjak.chagok.habit.service.creation;
+
+import com.jangjak.chagok.common.exception.CustomException;
+import com.jangjak.chagok.common.exception.ErrorCode;
+import com.jangjak.chagok.habit.dto.request.CustomHabitRequestDto;
+import com.jangjak.chagok.habit.dto.value.HabitCreationInfo;
+import com.jangjak.chagok.habit.entity.Action;
+import com.jangjak.chagok.habit.repository.HabitQuery;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class HabitCreationExisting extends HabitCreationBase {
+    private final HabitQuery habitQuery;
+
+    @Override
+    public HabitCreationInfo createHabit(CustomHabitRequestDto reqDto) {
+        // === 2-1: 기존 습관 재활용 케이스 ===
+
+        Long habitId = reqDto.getHabitId();
+
+        // 해당 ID의 습관이 실제로 존재하는지 확인
+        // 존재하지 않으면 CustomException(NOT_FOUND) 발생
+        habitQuery.getHabitById(habitId);
+
+        // 해당 습관에 연결된 모든 액션 조회
+        List<Action> actions = habitQuery.getActionsByHabitId(habitId);
+
+        // 액션이 하나도 없는 경우는 데이터 무결성 문제이므로 예외 발생
+        if (actions.isEmpty()) {
+            throw new CustomException(ErrorCode.DATASET_ERROR);
+        }
+
+        return new HabitCreationInfo(habitId, actions);
+    }
+}

--- a/src/main/java/com/jangjak/chagok/habit/service/creation/HabitCreationFactory.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/creation/HabitCreationFactory.java
@@ -1,0 +1,29 @@
+package com.jangjak.chagok.habit.service.creation;
+
+import com.jangjak.chagok.habit.dto.request.CustomHabitRequestDto;
+import com.jangjak.chagok.habit.dto.value.HabitCreationInfo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class HabitCreationFactory {
+
+    private final HabitCreationCustom habitCreationCustom;
+    private final HabitCreationExisting habitCreationExisting;
+
+    public HabitCreationInfo createHabit(CustomHabitRequestDto reqDto) {
+        HabitCreationBase habitCreation;
+
+        if (reqDto.getHabitId() == null) { // habitId가 null이라면 새로운 생성
+            habitCreation = habitCreationCustom;
+        } else { // habitId가 null이 아니라면 기존 습관 재활용
+            habitCreation = habitCreationExisting;
+        }
+
+        return habitCreation.createHabit(reqDto);
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,10 @@
 spring:
   application:
     name: chagok
+
+  jpa:
+    properties:
+      hibernate.jdbc.batch_size: 50
+
+  datasource:
+    url: jdbc:postgresql://localhost:5432/postgres?rewriteBatchedInserts=true


### PR DESCRIPTION
## 💡 변경사항 요약
- 사용자 정의 습관 등록 및 기존 습관 재사용 습관 등록 API 개발

## 🔨 주요 변경 내역
- AI를 사용하지 않는 모든 습관 생성이 동일한 API를 사용하도록 구현
- habitId의 유무를 통해 습관 생성 유형 구분
- 유효성 검증 로직 추가 구현 필요

## 🧪 테스트
- [ ] 직접 테스트 완료
- [ ] 관련 테스트 코드 작성/수정
