### PR TITLE
[CHA-119] 복합 키 설정 및 FK 구현방식 통일

### DIFF
--- a/src/main/java/com/jangjak/chagok/habit/controller/CheckMethodController.java
+++ b/src/main/java/com/jangjak/chagok/habit/controller/CheckMethodController.java
@@ -56,12 +56,15 @@ public class CheckMethodController {
 
     /**
      * Action 인증
+     * @return {
+     *     id : userActionId (기존 verifyId가 사라져 userActionId 반환 추후 반환값 논의 필요)
+     * }
      */
     @PostMapping("/{userActionId}")
     public ResponseEntity<?> actionVerify(@AuthenticationPrincipal TokenUserInfo userInfo,
                                           @PathVariable Long userActionId, @RequestBody List<@Valid ActionVerifyRequestDto> reqDto) {
-        Long verifyId = checkMethodService.actionVerify(userInfo.getId(), userActionId, reqDto);
-        return CommonResponse.toRes(verifyId, "인증이 완료되었습니다.");
+        Long id = checkMethodService.actionVerify(userInfo.getId(), userActionId, reqDto);
+        return CommonResponse.toRes(id, "인증이 완료되었습니다.");
     }
 
     /**

--- a/src/main/java/com/jangjak/chagok/habit/dto/request/ActionToAIReqDto.java
+++ b/src/main/java/com/jangjak/chagok/habit/dto/request/ActionToAIReqDto.java
@@ -38,9 +38,11 @@ public class ActionToAIReqDto {
     @Schema(description = "인증 방식(사진/이미지 | 글 작성)", example = "글 작성")
     private String verificationMethod;
 
+    @Builder.Default
     @Schema(description = "목표 기간", example = "8주")
     private Integer weeksCount = 8;     // 기본 8주
 
+    @Builder.Default
     @Schema(description = "사용할 모델", example = "gpt-4.1-mini", defaultValue = "gpt-4.1-mini")
     private String model = "gpt-4.1-mini";
 }

--- a/src/main/java/com/jangjak/chagok/habit/dto/request/HabitForActionReqDto.java
+++ b/src/main/java/com/jangjak/chagok/habit/dto/request/HabitForActionReqDto.java
@@ -26,6 +26,7 @@ public class HabitForActionReqDto {
 //    @Schema(description = "인증 방식(사진/이미지 | 글 작성)", example = "이미지")
 //    private String verificationMethod;
 
+    @Builder.Default
     @Schema(description = "목표 기간", example = "8")
     private Integer weeksCount = 8;     // 기본 8주
 

--- a/src/main/java/com/jangjak/chagok/habit/entity/Action.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/Action.java
@@ -1,6 +1,7 @@
 package com.jangjak.chagok.habit.entity;
 
 import com.jangjak.chagok.common.dto.BaseTimeEntity;
+import com.jangjak.chagok.habit.entity.keys.ActionCompositeKey;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,8 +16,8 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Table
 public class Action extends BaseTimeEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long actionId;
+    @EmbeddedId
+    private ActionCompositeKey id; // 복합키 설정
 
     @Column(nullable = false)
     private Long habitId;
@@ -34,8 +35,4 @@ public class Action extends BaseTimeEntity {
 
     @Column(nullable = false)
     private LocalDateTime validStartAt;
-
-    @Column(nullable = false)
-    private LocalDateTime validEndAt;
-
 }

--- a/src/main/java/com/jangjak/chagok/habit/entity/ActionVerify.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/ActionVerify.java
@@ -15,8 +15,9 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class ActionVerify {
+    // 식별 관계 설정
     @Id
-    private Long actionVerifyId;
+    private Long userActionId;
 
     @Column(nullable = false)
     private Long checkMethodId;
@@ -31,13 +32,7 @@ public class ActionVerify {
     @Column(nullable = false)
     private Integer methodOrder;
 
-    // 식별 관계 설정
-    @OneToOne
-    @MapsId
-    @JoinColumn(name = "user_action_id")
-    private UserAction userAction;
-
     public void assignUserAction(UserAction userAction) {
-        this.userAction = userAction;
+        this.userActionId = userAction.getUserActionId();
     }
 }

--- a/src/main/java/com/jangjak/chagok/habit/entity/CheckMethod.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/CheckMethod.java
@@ -1,6 +1,7 @@
 package com.jangjak.chagok.habit.entity;
 
 import com.jangjak.chagok.common.dto.BaseTimeEntity;
+import com.jangjak.chagok.habit.entity.keys.CheckMethodCompositeKey;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,9 +17,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class CheckMethod extends BaseTimeEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long checkMethodId;
+    @EmbeddedId
+    private CheckMethodCompositeKey id;
 
     @Column(nullable = false)
     private Long userId;
@@ -28,9 +28,6 @@ public class CheckMethod extends BaseTimeEntity {
 
     @Column(nullable = false)
     private LocalDateTime validStartAt;
-
-    @Column(nullable = false)
-    private LocalDateTime validEndAt;
 
     public void updateTitle(String title) {
         this.title = title;

--- a/src/main/java/com/jangjak/chagok/habit/entity/CheckMethodDetail.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/CheckMethodDetail.java
@@ -1,5 +1,6 @@
 package com.jangjak.chagok.habit.entity;
 
+import com.jangjak.chagok.habit.entity.keys.CheckMethodDetailCompositeKey;
 import com.jangjak.chagok.habit.enums.CheckMethodType;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -16,13 +17,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class CheckMethodDetail {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long checkMethodDetailId;
-
-    private Long checkMethodId;
-
-    @Column(nullable = false)
-    private Long methodOrder; // order가 postgresql 예약어라 이름 바꿈
+    @EmbeddedId
+    private CheckMethodDetailCompositeKey id;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -34,7 +30,4 @@ public class CheckMethodDetail {
 
     @Column(nullable = false)
     private LocalDateTime validStartAt;
-
-    @Column(nullable = false)
-    private LocalDateTime validEndAt;
 }

--- a/src/main/java/com/jangjak/chagok/habit/entity/Habit.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/Habit.java
@@ -2,6 +2,7 @@ package com.jangjak.chagok.habit.entity;
 
 import com.jangjak.chagok.common.dto.BaseTimeEntity;
 import com.jangjak.chagok.common.enums.YN;
+import com.jangjak.chagok.habit.entity.keys.HabitCompositeKey;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -15,8 +16,8 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Habit extends BaseTimeEntity {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long habitId;
+    @EmbeddedId
+    private HabitCompositeKey id;
 
     @Column(nullable = false)
     private Long category;
@@ -43,6 +44,4 @@ public class Habit extends BaseTimeEntity {
     @Column(nullable = false)
     private LocalDateTime validStartAt;
 
-    @Column(nullable = false)
-    private LocalDateTime validEndAt;
 }

--- a/src/main/java/com/jangjak/chagok/habit/entity/UserAction.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/UserAction.java
@@ -45,9 +45,4 @@ public class UserAction extends BaseTimeEntity {
     public void complete() {
         this.isCompleted = YN.Y;
     }
-
-    //부모 매핑관계 설정이 맞는진 모르겠습니다..
-    @OneToOne(mappedBy = "userAction", cascade = CascadeType.ALL, orphanRemoval = true)
-    private ActionVerify actionVerify;
-
 }

--- a/src/main/java/com/jangjak/chagok/habit/entity/keys/ActionCompositeKey.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/keys/ActionCompositeKey.java
@@ -1,0 +1,24 @@
+package com.jangjak.chagok.habit.entity.keys;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@Builder
+public class ActionCompositeKey implements Serializable {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long actionId;
+
+    @Column(nullable = false)
+    private LocalDateTime validEndAt;
+}

--- a/src/main/java/com/jangjak/chagok/habit/entity/keys/CheckMethodCompositeKey.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/keys/CheckMethodCompositeKey.java
@@ -1,0 +1,24 @@
+package com.jangjak.chagok.habit.entity.keys;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@Builder
+public class CheckMethodCompositeKey implements Serializable {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long checkMethodId;
+
+    @Column(nullable = false)
+    private LocalDateTime validEndAt;
+}

--- a/src/main/java/com/jangjak/chagok/habit/entity/keys/CheckMethodDetailCompositeKey.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/keys/CheckMethodDetailCompositeKey.java
@@ -1,0 +1,25 @@
+package com.jangjak.chagok.habit.entity.keys;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@Builder
+public class CheckMethodDetailCompositeKey implements Serializable {
+    @Column(nullable = false)
+    private Long checkMethodId;
+
+    @Column(nullable = false)
+    private Long methodOrder; // order가 postgresql 예약어라 이름 바꿈
+
+    @Column(nullable = false)
+    private LocalDateTime validEndAt;
+}

--- a/src/main/java/com/jangjak/chagok/habit/entity/keys/HabitCompositeKey.java
+++ b/src/main/java/com/jangjak/chagok/habit/entity/keys/HabitCompositeKey.java
@@ -1,0 +1,21 @@
+package com.jangjak.chagok.habit.entity.keys;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@Builder
+public class HabitCompositeKey implements Serializable {
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long habitId;
+
+    @Column(nullable = false)
+    private LocalDateTime validEndAt;
+}

--- a/src/main/java/com/jangjak/chagok/habit/repository/ActionVerifyRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/ActionVerifyRepository.java
@@ -3,5 +3,8 @@ package com.jangjak.chagok.habit.repository;
 import com.jangjak.chagok.habit.entity.ActionVerify;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ActionVerifyRepository extends JpaRepository<ActionVerify, Long> {
+    Optional<ActionVerify> getActionVerifyByUserActionId(Long userActionId);
 }

--- a/src/main/java/com/jangjak/chagok/habit/repository/CheckMethodDetailRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/CheckMethodDetailRepository.java
@@ -6,6 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface CheckMethodDetailRepository extends JpaRepository<CheckMethodDetail, Long> {
-     List<CheckMethodDetail> findByCheckMethodIdOrderByMethodOrderAsc(Long checkMethodId);
-     void deleteAllByCheckMethodId(Long checkMethodId);
+     List<CheckMethodDetail> findByIdCheckMethodIdOrderByIdMethodOrderAsc(Long checkMethodId);
+     void deleteAllByIdCheckMethodId(Long checkMethodId);
 }

--- a/src/main/java/com/jangjak/chagok/habit/repository/CheckMethodRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/CheckMethodRepository.java
@@ -7,5 +7,5 @@ import java.util.Collection;
 import java.util.List;
 
 public interface CheckMethodRepository extends JpaRepository<CheckMethod, Long> {
-    List<CheckMethod> getCheckMethodsByCheckMethodIdIn(Collection<Long> ids);
+    List<CheckMethod> getCheckMethodsByIdCheckMethodIdIn(Collection<Long> ids);
 }

--- a/src/main/java/com/jangjak/chagok/habit/repository/HabitQuery.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/HabitQuery.java
@@ -56,7 +56,7 @@ public class HabitQuery {
 //    }
 
     public boolean isUserCheckMethod(Long userId, List<Long> checkMethodIdList) {
-        List<CheckMethod> methodList = checkMethodRepository.getCheckMethodsByCheckMethodIdIn(checkMethodIdList);
+        List<CheckMethod> methodList = checkMethodRepository.getCheckMethodsByIdCheckMethodIdIn(checkMethodIdList);
         for (CheckMethod method : methodList) {
             if (!method.getUserId().equals(userId)) {
                 return false;
@@ -86,12 +86,12 @@ public class HabitQuery {
     }
 
     public boolean isTemplateHabit(Long habitId) {
-        return habitRepository.findByHabitIdAndIsTemplate(habitId, YN.Y).isPresent();
+        return habitRepository.findByIdHabitIdAndIsTemplate(habitId, YN.Y).isPresent();
     }
 
     // 일치하는 Habit이 없다면 null 반환
     public Habit getTemplateHabit(Long habitId) {
-        return habitRepository.findByHabitIdAndIsTemplate(habitId, YN.Y).orElse(null);
+        return habitRepository.findByIdHabitIdAndIsTemplate(habitId, YN.Y).orElse(null);
     }
 
     public List<ProgressRateInfo> findProgressRates(List<Long> userHabitIds, YN isCompleted) {

--- a/src/main/java/com/jangjak/chagok/habit/repository/HabitRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/HabitRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface HabitRepository extends JpaRepository<Habit, Long> {
-    Optional<Habit> findByHabitIdAndIsTemplate(Long id, YN isTemplate);
+    Optional<Habit> findByIdHabitIdAndIsTemplate(Long id, YN isTemplate);
 }

--- a/src/main/java/com/jangjak/chagok/habit/repository/PopularHabitCategoryRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/PopularHabitCategoryRepository.java
@@ -1,11 +1,7 @@
 package com.jangjak.chagok.habit.repository;
 
-import com.jangjak.chagok.habit.dto.value.PopularCategoryDto;
 import com.jangjak.chagok.habit.entity.PopularHabitCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-
-import java.util.List;
 
 public interface PopularHabitCategoryRepository extends JpaRepository<PopularHabitCategory, Long> {
 //    @Query("""

--- a/src/main/java/com/jangjak/chagok/habit/repository/QueryRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/QueryRepository.java
@@ -76,7 +76,7 @@ public class QueryRepository {
                         userAction.isCompleted
                 ))
                 .from(userAction)
-                .join(action).on(action.actionId.eq(userAction.actionId))
+                .join(action).on(action.id.actionId.eq(userAction.actionId))
                 .join(userHabit).on(userHabit.userHabitId.eq(userAction.userHabitId))
                 .where(builder)
                 .orderBy(

--- a/src/main/java/com/jangjak/chagok/habit/service/CheckMethodService.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/CheckMethodService.java
@@ -11,6 +11,7 @@ import com.jangjak.chagok.habit.dto.response.CheckMethodDetailRestDto;
 import com.jangjak.chagok.habit.dto.response.CheckMethodResDto;
 import com.jangjak.chagok.habit.dto.response.VerifyOfActionResDto;
 import com.jangjak.chagok.habit.entity.*;
+import com.jangjak.chagok.habit.entity.keys.CheckMethodDetailCompositeKey;
 import com.jangjak.chagok.habit.repository.ActionVerifyRepository;
 import com.jangjak.chagok.habit.repository.CheckMethodDetailRepository;
 import com.jangjak.chagok.habit.repository.CheckMethodRepository;
@@ -67,8 +68,13 @@ public class CheckMethodService {
         // checkMethodDetail: checkMethodId, order, type, value
         List<CheckMethodDetail> detailEntities = requestDto.getDetails().stream()
                 .map(detailDto -> CheckMethodDetail.builder()
-                        .checkMethodId(savedCheckMethod.getCheckMethodId())
-                        .methodOrder(detailDto.getMethodOrder())
+                        .id(
+                               CheckMethodDetailCompositeKey.builder()
+                                       .checkMethodId(savedCheckMethod.getId().getCheckMethodId())
+                                       .methodOrder(detailDto.getMethodOrder())
+                                       // TODO
+                                       .build()
+                        )
                         .type(detailDto.getType())
                         .value(detailDto.getValue())
                         .build())
@@ -76,7 +82,7 @@ public class CheckMethodService {
 
         checkMethodDetailRepository.saveAll(detailEntities);
 
-        return savedCheckMethod.getCheckMethodId();
+        return savedCheckMethod.getId().getCheckMethodId();
     }
 
     /**
@@ -108,13 +114,17 @@ public class CheckMethodService {
         checkMethod.updateTitle(requestDto.getTitle());
 
         // 기존 detail 삭제
-        checkMethodDetailRepository.deleteAllByCheckMethodId(checkMethodId);
+        checkMethodDetailRepository.deleteAllByIdCheckMethodId(checkMethodId);
 
         // 새 detail 생성
         List<CheckMethodDetail> newDetails = requestDto.getDetails().stream()
                 .map(dto -> CheckMethodDetail.builder()
-                        .checkMethodId(checkMethodId)
-                        .methodOrder(dto.getMethodOrder())
+                        .id(CheckMethodDetailCompositeKey.builder()
+                                .checkMethodId(checkMethodId)
+                                .methodOrder(dto.getMethodOrder())
+                                // TODO
+                                .build()
+                        )
                         .type(dto.getType())
                         .value(dto.getValue())
                         .build())
@@ -140,7 +150,7 @@ public class CheckMethodService {
         }
 
         // 이미 인증된 데이터라면 에러
-        if (userAction.getActionVerify() != null) {
+        if (actionVerifyRepository.getActionVerifyByUserActionId(userActionId).isPresent()) {
             throw new CustomException(ErrorCode.ALREADY_VERIFIED);
         }
 
@@ -197,7 +207,7 @@ public class CheckMethodService {
         actionVerifyRepository.save(verify);
         userAction.complete();
 
-        return verify.getActionVerifyId();
+        return verify.getUserActionId();
     }
 
     /**
@@ -216,7 +226,7 @@ public class CheckMethodService {
         CheckMethod checkMethod = checkMethodRepository.findById(checkMethodId).orElseThrow(
                 () -> new CustomException(ErrorCode.NOT_FOUND));
 
-        List<CheckMethodDetail> details = checkMethodDetailRepository.findByCheckMethodIdOrderByMethodOrderAsc(checkMethodId);
+        List<CheckMethodDetail> details = checkMethodDetailRepository.findByIdCheckMethodIdOrderByIdMethodOrderAsc(checkMethodId);
 
         if (details.isEmpty()) {
             throw new CustomException(ErrorCode.NOT_FOUND);
@@ -226,7 +236,7 @@ public class CheckMethodService {
                 .map(detail -> CheckMethodDetailRestDto.builder()
                         .type(detail.getType())
                         .value(detail.getValue())
-                        .methodOrder(detail.getMethodOrder())
+                        .methodOrder(detail.getId().getMethodOrder())
                         .build()
                 ).toList();
 

--- a/src/main/java/com/jangjak/chagok/habit/service/creation/ModifyHabitCreation.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/creation/ModifyHabitCreation.java
@@ -104,13 +104,13 @@ public class ModifyHabitCreation implements HabitCreation {
 
         Map<Long, Action> actionMap = habitQuery.getActionsByHabitId(oldHabitId).stream()
                 .collect(Collectors.toMap(
-                        Action::getActionId,
+                        e -> e.getId().getActionId(),
                         Function.identity()
                 ));
 
         // 습관 저장
         Habit habit = HabitMapper.toEntity(request, oldHabit);
-        Long habitId = habitQuery.saveHabit(habit).getHabitId();
+        Long habitId = habitQuery.saveHabit(habit).getId().getHabitId();
 
         List<Action> actionResult = new ArrayList<>();
         for (ModifyActionRequestDto reqAction : reqActions) {
@@ -157,7 +157,7 @@ public class ModifyHabitCreation implements HabitCreation {
         // UserAction 생성 및 저장
         List<UserAction> userActions = new ArrayList<>();
         for (int i = 0; i < requestActions.size(); i++) {
-            Long actionId = actions.get(i).getActionId();
+            Long actionId = actions.get(i).getId().getActionId();
             LocalDate actionDate = requestActions.get(i).getActionDate();
 
             UserAction userAction = UserActionMapper.toEntity(userHabitId, actionId, actionDate);

--- a/src/main/java/com/jangjak/chagok/habit/service/creation/NewHabitCreation.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/creation/NewHabitCreation.java
@@ -78,7 +78,7 @@ public class NewHabitCreation implements HabitCreation {
         LocalDate end = request.getEndDate();
 
         Habit habit = HabitMapper.toEntity(request);
-        Long habitId = habitQuery.saveHabit(habit).getHabitId();
+        Long habitId = habitQuery.saveHabit(habit).getId().getHabitId();
 
         // Action DB 저장
         List<Action> actions = ActionMapper.toEntities(habitId, request);
@@ -108,7 +108,7 @@ public class NewHabitCreation implements HabitCreation {
         // UserAction 생성 및 저장
         List<UserAction> userActions = new ArrayList<>();
         for (int i = 0; i < requestActions.size(); i++) {
-            Long actionId = actions.get(i).getActionId();
+            Long actionId = actions.get(i).getId().getActionId();
             LocalDate actionDate = requestActions.get(i).getActionDate();
 
             UserAction userAction = UserActionMapper.toEntity(userHabitId, actionId, actionDate);

--- a/src/main/java/com/jangjak/chagok/habit/service/creation/TemplateHabitCreation.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/creation/TemplateHabitCreation.java
@@ -79,7 +79,7 @@ public class TemplateHabitCreation implements HabitCreation {
         // UserAction 생성 및 저장
         List<UserAction> userActions = new ArrayList<>();
         for (int i = 0; i < requestActions.size(); i++) {
-            Long actionId = actions.get(i).getActionId();
+            Long actionId = actions.get(i).getId().getActionId();
             LocalDate actionDate = requestActions.get(i).getActionDate();
 
             // actionId가 실제로 존재하는지

--- a/src/main/java/com/jangjak/chagok/habit/service/read/HabitReadService.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/read/HabitReadService.java
@@ -67,7 +67,7 @@ public class HabitReadService {
                 .collect(Collectors.toMap(UserHabit::getUserHabitId, UserHabit::getHabitId));
 
         Map<Long, Habit> habitMap = habitList.stream()
-                .collect(Collectors.toMap(Habit::getHabitId, Function.identity()));
+                .collect(Collectors.toMap(e -> e.getId().getHabitId(), Function.identity()));
 
         // 진행률 계산
         List<ProgressRateInfo> rawList = habitQuery.findProgressRates(userHabitIds, YN.Y);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
@@ -20,6 +20,11 @@ spring:
   batch:
     job:
       enabled: false  # 자동 실행 끄기
+  data:
+    redis:
+      repositories:
+        enabled: false
+
 # DB 날린 경우 (혹은 배치 처음 실행할 경우) 주석 해제
 #    jdbc:
 #      initialize-schema: always


### PR DESCRIPTION
## 💡 변경사항 요약
- 복합키 설정

## 🔨 주요 변경 내역
- ERD 상 복합키가 필요한 엔터티들에 복합키 구현 및 기존 코드가 동일하게 동작하도록 수정
- UserAction과 ActionVerify 사이 JPA 어노테이션을 통한 FK 설정 삭제 및 FK 설정 통일
- redis가 모든 repository 인터페이스를 풀스캔하던 작업 비활성화 및 기타 로그 정리

## 🧪 테스트
- [X] 실행 가능 테스트

## 📌 기타 참고 사항
- [Confluence] 06. BE 개발/복합키 관련 유의사항 : 복합키 내부 필드 사용 시 기존과 달라진 방식에 대한 비교 및 설명 작성
