### PR TITLE
[CHA-171] 인증방식 삭제 API 구현

### DIFF
--- a/src/main/java/com/jangjak/chagok/habit/controller/CheckMethodController.java
+++ b/src/main/java/com/jangjak/chagok/habit/controller/CheckMethodController.java
@@ -10,7 +10,6 @@ import com.jangjak.chagok.habit.service.CheckMethodService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.boot.actuate.web.exchanges.HttpExchange;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/com/jangjak/chagok/habit/controller/CheckMethodController.java
+++ b/src/main/java/com/jangjak/chagok/habit/controller/CheckMethodController.java
@@ -10,6 +10,7 @@ import com.jangjak.chagok.habit.service.CheckMethodService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.actuate.web.exchanges.HttpExchange;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -74,5 +75,14 @@ public class CheckMethodController {
     public ResponseEntity<?> getVerifyOfAction(@AuthenticationPrincipal TokenUserInfo userInfo, @PathVariable Long userActionId) {
         VerifyOfActionResDto verifyOfAction = checkMethodService.getVerifyOfAction(userInfo.getId(), userActionId);
         return CommonResponse.toRes(verifyOfAction, "인증 내역이 조회되었습니다.");
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteCheckMethod(
+            @AuthenticationPrincipal TokenUserInfo userInfo,
+            @PathVariable(name = "id") Long checkMethodId
+    ) {
+        checkMethodService.deleteCheckMethod(userInfo.getId(), checkMethodId);
+        return CommonResponse.toRes(checkMethodId, "인증 방식이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/jangjak/chagok/habit/repository/CheckMethodDetailRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/CheckMethodDetailRepository.java
@@ -2,10 +2,29 @@ package com.jangjak.chagok.habit.repository;
 
 import com.jangjak.chagok.habit.entity.CheckMethodDetail;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CheckMethodDetailRepository extends JpaRepository<CheckMethodDetail, Long> {
      List<CheckMethodDetail> findByIdCheckMethodIdOrderByIdMethodOrderAsc(Long checkMethodId);
      void deleteAllByIdCheckMethodId(Long checkMethodId);
+
+    @Modifying
+    @Query(
+            value = """
+                        UPDATE check_method_detail
+                        SET valid_end_at = :validStDt
+                        WHERE check_method_id = :checkMethodId
+                        AND valid_end_at = :max
+                    """, nativeQuery = true
+    )
+    void expireCheckMethodDetail(
+            @Param("checkMethodId") Long checkMethodId,
+            @Param("validStDt") LocalDateTime validStDt,
+            @Param("max") LocalDateTime max
+    );
 }

--- a/src/main/java/com/jangjak/chagok/habit/repository/CheckMethodRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/CheckMethodRepository.java
@@ -2,10 +2,47 @@ package com.jangjak.chagok.habit.repository;
 
 import com.jangjak.chagok.habit.entity.CheckMethod;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 public interface CheckMethodRepository extends JpaRepository<CheckMethod, Long> {
     List<CheckMethod> getCheckMethodsByIdCheckMethodIdIn(Collection<Long> ids);
+
+
+    @Query(
+            value = """
+                        SELECT *
+                        FROM check_method 
+                        WHERE valid_end_at > :now 
+                        AND valid_start_at <= :now 
+                        AND check_method_id = :checkMethodId
+                    """,
+            nativeQuery = true
+    )
+    Optional<CheckMethod> findByCheckMethodId(
+            @Param("now") LocalDateTime now,
+            @Param("checkMethodId") Long checkMethodId
+    );
+
+
+    @Modifying
+    @Query(
+            value = """
+                        UPDATE check_method 
+                        SET valid_end_at = :validStDt
+                        WHERE check_method_id = :checkMethodId
+                        AND valid_end_at = :max
+                    """, nativeQuery = true
+    )
+    void expireCheckMethod(
+            @Param("checkMethodId") Long checkMethodId,
+            @Param("validStDt") LocalDateTime validStDt,
+            @Param("max") LocalDateTime max
+    );
 }

--- a/src/main/java/com/jangjak/chagok/habit/service/CheckMethodService.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/CheckMethodService.java
@@ -276,4 +276,24 @@ public class CheckMethodService {
                 .details(verifyList)
                 .build();
     }
+
+    public void deleteCheckMethod(Long userId, Long checkMethodId) {
+        LocalDateTime validStDt = LocalDateTime.now();
+
+        // 인증 방식 조회
+        CheckMethod checkMethod = checkMethodRepository.findByCheckMethodId(validStDt, checkMethodId).orElseThrow(
+                () -> new CustomException(ErrorCode.NOT_FOUND)
+        );
+
+        // 사용자가 생성한 인증 방식이 맞는 지 확인
+        if (!checkMethod.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN);
+        }
+
+        // 인증 방식 만료
+        checkMethodRepository.expireCheckMethod(checkMethodId, validStDt, LocalDateTime.MAX);
+
+        // 인증 방식 세부 사항 만료
+        checkMethodDetailRepository.expireCheckMethodDetail(checkMethodId, validStDt, LocalDateTime.MAX);
+    }
 }

--- a/src/main/java/com/jangjak/chagok/habit/service/CheckMethodService.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/CheckMethodService.java
@@ -277,6 +277,7 @@ public class CheckMethodService {
                 .build();
     }
 
+    @Transactional
     public void deleteCheckMethod(Long userId, Long checkMethodId) {
         LocalDateTime validStDt = LocalDateTime.now();
 


### PR DESCRIPTION
## 💡 변경사항 요약
- [CHA-171] 습관 인증방식 삭제 API 구현

## 🔨 주요 변경 내역
- 사용자가 생성한 인증방식만 만료시킬 수 있도록 구현
- 인증방식 세부 내용도 함께 만료

## 📌 기타 참고 사항


[CHA-171]: https://hwaha0824-1758974452105.atlassian.net/browse/CHA-171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 습관의 체크 방법을 삭제할 수 있는 기능이 추가되었습니다. 삭제 시 해당 체크 방법과 관련된 세부 항목들이 자동으로 정리됩니다.
  * 소유자만 삭제할 수 있으며, 존재하지 않거나 권한이 없는 경우 적절한 오류 안내가 제공됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->