### PR TITLE
[CHA-96] 타인 습관 조회 API 생성 및 QueryDSL 버전업

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,10 +62,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 
     //QueryDSL
-	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
-	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
-	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+    implementation("io.github.openfeign.querydsl:querydsl-jpa:7.1")
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.1:jakarta"
+
     // OPEN AI
     implementation 'org.springframework.ai:spring-ai-openai:1.0.0-M6'
     implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter:1.0.0-M6'

--- a/src/main/java/com/jangjak/chagok/admin/repository/UserHabitStatsQueryRepositoryImpl.java
+++ b/src/main/java/com/jangjak/chagok/admin/repository/UserHabitStatsQueryRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.jangjak.chagok.admin.repository;
 import com.jangjak.chagok.admin.dto.info.HabitProgressDto;
 import com.jangjak.chagok.common.enums.YN;
 import com.jangjak.chagok.habit.enums.HabitState;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -47,15 +48,15 @@ public class UserHabitStatsQueryRepositoryImpl implements UserHabitStatsQueryRep
                         .otherwise(0L);
 
         return queryFactory
-                .select(com.querydsl.core.types.Projections.constructor(
+                .select(Projections.constructor(
                         HabitProgressDto.class,
                         userHabit.userHabitId,                    // userHabitId
                         userHabit.userId,               // userId
                         userHabit.state,                 // habitState
                         userAction.userActionId.count(),           // totalCount
-                        totalCompleted.sum(),        // totalCompleted
-                        untilBaseCount.sum(),        // untilBaseCount
-                        untilBaseCompleted.sum()     // untilBaseCompleted
+                        totalCompleted.sumLong(),        // totalCompleted
+                        untilBaseCount.sumLong(),        // untilBaseCount
+                        untilBaseCompleted.sumLong()     // untilBaseCompleted
                 ))
                 .from(userAction)
                 .join(userHabit).on(userHabit.userHabitId.eq(userAction.userHabitId))

--- a/src/main/java/com/jangjak/chagok/common/exception/ErrorCode.java
+++ b/src/main/java/com/jangjak/chagok/common/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     AI_RESPONSE_ERROR("AI 응답이 비어 있습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     AI_RESPONSE_MAPPING_ERROR("AI 계획 생성 실패: 결과가 비어 있습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
     AI_REQUEST_ERROR("AI 계획 생성 중 오류 발생", HttpStatus.INTERNAL_SERVER_ERROR),
+    BAD_PAGE_REQUEST("페이징 관련 변수에 잘못된 값이 요청되었습니다.", HttpStatus.BAD_REQUEST),
     ;
 
     final String message;

--- a/src/main/java/com/jangjak/chagok/habit/controller/HabitController.java
+++ b/src/main/java/com/jangjak/chagok/habit/controller/HabitController.java
@@ -9,6 +9,7 @@ import com.jangjak.chagok.habit.dto.request.update.HabitUpdateRequestDto;
 import com.jangjak.chagok.habit.dto.response.CalendarViewResDto;
 import com.jangjak.chagok.habit.dto.response.HabitDashboardResDto;
 import com.jangjak.chagok.habit.dto.response.HabitDetailResDto;
+import com.jangjak.chagok.habit.dto.value.PublicHabitInfo;
 import com.jangjak.chagok.habit.enums.HabitState;
 import com.jangjak.chagok.habit.service.create.HabitCreateService;
 import com.jangjak.chagok.habit.service.delete.HabitDeleteService;
@@ -117,5 +118,13 @@ public class HabitController implements HabitControllerDocs {
         return CommonResponse.toRes(actionDetail,"습관 상세 정보가 조회되었습니다.");
     }
 
+    /**
+     * 타인 습관 조회
+     * */
+    @GetMapping("/others")
+    public ResponseEntity<?> getOtherHabits(@AuthenticationPrincipal TokenUserInfo userInfo, @RequestParam Integer page, @RequestParam Integer size, @RequestParam String category) {
+        List<PublicHabitInfo> otherHabits = habitReadService.getOtherHabits(page, size, category);
+        return CommonResponse.toRes(otherHabits, "사랑방 습관 정보가 성공적으로 조회되었습니다.");
+    }
 
 }

--- a/src/main/java/com/jangjak/chagok/habit/dto/value/PublicHabitInfo.java
+++ b/src/main/java/com/jangjak/chagok/habit/dto/value/PublicHabitInfo.java
@@ -1,0 +1,19 @@
+package com.jangjak.chagok.habit.dto.value;
+
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class PublicHabitInfo {
+    private Long id;
+    private String habitImage;
+    private Integer habitFreqCount;
+    private Integer habitFreqUnit;
+    private Integer habitFrequency;
+    private String habitTitle;
+    private LocalDate habitStartDate;
+    private LocalDate habitEndDate;
+    private String userName;
+    private String userProfileImage;
+}

--- a/src/main/java/com/jangjak/chagok/habit/enums/HabitCategory.java
+++ b/src/main/java/com/jangjak/chagok/habit/enums/HabitCategory.java
@@ -1,26 +1,39 @@
 package com.jangjak.chagok.habit.enums;
 
+import java.util.Locale;
+import java.util.Objects;
+
 public enum HabitCategory {
-    NONE(0),
-    HEALTH(1),
-    LEARNING(2),
-    LIFESTYLE(3),
-    OTHER(4),
+    NONE(0L),
+    HEALTH(1L),
+    LEARNING(2L),
+    LIFESTYLE(3L),
+    OTHER(4L),
     ;
 
-    final int value;
+    final Long value;
 
-    HabitCategory(int value) {
+    HabitCategory(Long value) {
         this.value = value;
     }
 
-    public int value() {
+    public Long value() {
         return value;
     }
 
     public static HabitCategory fromValue(int value) {
+        Long valueLong = (long) value;
         for (HabitCategory category : HabitCategory.values()) {
-            if (category.value == value) {
+            if (Objects.equals(category.value, valueLong)) {
+                return category;
+            }
+        }
+        return NONE;
+    }
+
+    public static HabitCategory fromName(String name) {
+        for (HabitCategory category : HabitCategory.values()) {
+            if (category.name().equalsIgnoreCase(name)) {
                 return category;
             }
         }

--- a/src/main/java/com/jangjak/chagok/habit/repository/HabitQuery.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/HabitQuery.java
@@ -5,7 +5,9 @@ import com.jangjak.chagok.common.exception.CustomException;
 import com.jangjak.chagok.common.exception.ErrorCode;
 import com.jangjak.chagok.habit.dto.value.ActionAndUserActionView;
 import com.jangjak.chagok.habit.dto.value.ProgressRateInfo;
+import com.jangjak.chagok.habit.dto.value.PublicHabitInfo;
 import com.jangjak.chagok.habit.entity.*;
+import com.jangjak.chagok.habit.enums.HabitCategory;
 import com.jangjak.chagok.habit.enums.HabitState;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -146,5 +148,10 @@ public class HabitQuery {
     public Habit findByHabitIdAndCreatedAt(Long habitId, LocalDateTime createdAt) {
         return queryRepository.findByHabitIdAndCreatedAt(habitId, createdAt)
                 .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+    }
+
+    public List<PublicHabitInfo> findPublicHabit(Integer page, Integer size, HabitCategory habitCategory) {
+        if (page <= 0) throw new CustomException(ErrorCode.BAD_PAGE_REQUEST);
+        return queryRepository.findPublicHabit(page, size, habitCategory);
     }
 }

--- a/src/main/java/com/jangjak/chagok/habit/repository/HabitRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/HabitRepository.java
@@ -2,6 +2,7 @@ package com.jangjak.chagok.habit.repository;
 
 import com.jangjak.chagok.common.enums.YN;
 import com.jangjak.chagok.habit.entity.Habit;
+import com.jangjak.chagok.habit.entity.UserHabit;
 import com.jangjak.chagok.habit.entity.keys.HabitCompositeKey;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;

--- a/src/main/java/com/jangjak/chagok/habit/repository/QueryRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/QueryRepository.java
@@ -1,7 +1,10 @@
 package com.jangjak.chagok.habit.repository;
 
+import com.jangjak.chagok.common.enums.YN;
 import com.jangjak.chagok.habit.dto.value.CalendarInfo;
+import com.jangjak.chagok.habit.dto.value.PublicHabitInfo;
 import com.jangjak.chagok.habit.entity.*;
+import com.jangjak.chagok.habit.enums.HabitCategory;
 import com.jangjak.chagok.habit.enums.HabitState;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
@@ -21,6 +24,7 @@ import static com.jangjak.chagok.habit.entity.QHabit.habit;
 import static com.jangjak.chagok.habit.entity.QUserHabit.userHabit;
 import static com.jangjak.chagok.habit.entity.QUserAction.userAction;
 import static com.jangjak.chagok.habit.entity.QAction.action;
+import static com.jangjak.chagok.user.entity.QUser.user;
 
 @Component
 @RequiredArgsConstructor
@@ -147,4 +151,34 @@ public class QueryRepository {
                 .fetch();
     }
 
+    public List<PublicHabitInfo> findPublicHabit(Integer page, Integer size, HabitCategory category) {
+        BooleanBuilder predicate = new BooleanBuilder();
+        if (category != HabitCategory.NONE) predicate = predicate.and(habit.category.eq(category.value()));
+
+        return factory
+                .select(
+                        Projections.constructor(
+                                PublicHabitInfo.class,
+                                habit.image, habit.freqCount, habit.freqUnit, habit.frequency, habit.title,
+                                userHabit.startDate, userHabit.endDate,
+                                user.name, user.profileImage
+                        )
+                )
+                .from(userHabit)
+                .join(habit).on(
+                        habit.id.habitId.eq(userHabit.habitId),
+                        habit.id.validEndAt.gt(userHabit.createdAt),
+                        habit.validStartAt.loe(userHabit.createdAt)
+                )
+                .join(user).on(user.userId.eq(userHabit.userId))
+                .where(
+                        userHabit.isPublic.eq(YN.Y),
+                        userHabit.state.eq(HabitState.IN_PROGRESS),
+                        userHabit.startDate.loe(LocalDate.now()),
+                        predicate
+                )
+                .offset((long) (page - 1) * size)
+                .limit(size)
+                .fetch();
+    }
 }

--- a/src/main/java/com/jangjak/chagok/habit/repository/QueryRepository.java
+++ b/src/main/java/com/jangjak/chagok/habit/repository/QueryRepository.java
@@ -159,6 +159,7 @@ public class QueryRepository {
                 .select(
                         Projections.constructor(
                                 PublicHabitInfo.class,
+                                userHabit.userHabitId,
                                 habit.image, habit.freqCount, habit.freqUnit, habit.frequency, habit.title,
                                 userHabit.startDate, userHabit.endDate,
                                 user.name, user.profileImage

--- a/src/main/java/com/jangjak/chagok/habit/service/read/HabitReadService.java
+++ b/src/main/java/com/jangjak/chagok/habit/service/read/HabitReadService.java
@@ -7,6 +7,7 @@ import com.jangjak.chagok.habit.dto.response.*;
 import com.jangjak.chagok.habit.dto.value.ActionAndUserActionView;
 import com.jangjak.chagok.habit.dto.value.CalendarInfo;
 import com.jangjak.chagok.habit.dto.value.ProgressRateInfo;
+import com.jangjak.chagok.habit.dto.value.PublicHabitInfo;
 import com.jangjak.chagok.habit.entity.*;
 import com.jangjak.chagok.habit.enums.HabitState;
 import com.jangjak.chagok.habit.repository.CheckMethodRepository;
@@ -251,5 +252,9 @@ public class HabitReadService {
             return 0;
         }
         return (int) Math.floor((completed * 100.0) / total);
+    }
+
+    public List<PublicHabitInfo> getOtherHabits(Integer page, Integer size, String category) {
+        return habitQuery.findPublicHabit(page, size, HabitCategory.fromName(category));
     }
 }


### PR DESCRIPTION
## 💡 변경사항 요약
- [CHA-96] 타인 습관 조회 API 생성

## 🔨 주요 변경 내역
- 타인 습관 조회 API 생성 (ORDER BY 조건 제외)
- QueryDSL 버전 업 (기존 QueryDSL이 지원이 중단되어 지속적으로 지원이 제공되는 버전으로 변경)

## 🧪 테스트
- 테스트는 못했습니다..

## 📌 기타 참고 사항
- https://github.com/OpenFeign/querydsl


[CHA-96]: https://hwaha0824-1758974452105.atlassian.net/browse/CHA-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 카테고리별로 다른 사용자의 공개된 습관을 페이지네이션으로 조회할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * 잘못된 페이징 요청에 대해 명확한 400 응답 오류가 반환되도록 개선되었습니다.

* **Chores**
  * QueryDSL 관련 의존성 구성이 업데이트되어 빌드 안정성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->